### PR TITLE
Devcontainer fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,10 +17,11 @@
   "forwardPorts": [],
   "workspaceMount": "source=${localWorkspaceFolder}/workspace,target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
-  // "postStartCommand": "code /esp-idf.code-workspace",
+  // "postStartCommand": "code --file-uri /zephyr.code-workspace", // Does not work
   "runArgs": [
     "--name",
     "Zephyr-Introduction",
+    "--rm",
     "-it",
     "-p",
     "2222:22",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,33 @@
 {
-    "name": "Zephyr Development Environment for Espressif",
-    "image": "env-zephyr-espressif",
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "ms-vscode.cpptools",
-                "ms-vscode.cmake-tools",
-                "nordic-semiconductor.nrf-devicetree",
-                "ms-vscode.hexeditor"
-            ]
-        }
-    },
-    "forwardPorts": [
-    ],
-    "workspaceMount": "source=${localWorkspaceFolder}/workspace,target=/workspace,type=bind,consistency=cached",
-    "workspaceFolder": "/workspace",
-    // "postStartCommand": "code /esp-idf.code-workspace",
-    "runArgs": [
-        "--rm",
-        "-it",
-        "-p", "2222:22",
-        "-p", "3333:3333",
-        "-p", "8800:8800"
-    ],
-    "remoteUser": "root"
+  "name": "Zephyr Development Environment for Espressif",
+  "build": {
+    "dockerfile": "../Dockerfile.espressif",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "nordic-semiconductor.nrf-devicetree",
+        "ms-vscode.hexeditor"
+      ]
+    }
+  },
+  "forwardPorts": [],
+  "workspaceMount": "source=${localWorkspaceFolder}/workspace,target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace",
+  // "postStartCommand": "code /esp-idf.code-workspace",
+  "runArgs": [
+    "--name",
+    "Zephyr-Introduction",
+    "-it",
+    "-p",
+    "2222:22",
+    "-p",
+    "3333:3333",
+    "-p",
+    "8800:8800"
+  ],
+  "remoteUser": "root"
 }

--- a/Dockerfile.espressif
+++ b/Dockerfile.espressif
@@ -44,10 +44,10 @@ SHELL ["/bin/bash", "-c"]
 
 # Check if the target architecture is either x86_64 (amd64) or arm64 (aarch64)
 RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
-    echo "Architecture $TARGETARCH is supported."; \
+        echo "Architecture $TARGETARCH is supported."; \
     else \
-    echo "Unsupported architecture: $TARGETARCH"; \
-    exit 1; \
+        echo "Unsupported architecture: $TARGETARCH"; \
+        exit 1; \
     fi
 
 # Set non-interactive frontend for apt-get to skip any user confirmations
@@ -56,26 +56,26 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install base packages
 RUN apt-get -y update && \
     apt-get install --no-install-recommends -y \
-    dos2unix \
-    ca-certificates \
-    file \
-    locales \
-    git \
-    build-essential \
-    cmake \
-    ninja-build gperf \
-    device-tree-compiler \
-    wget \
-    curl \
-    python3 \
-    python3-pip \
-    python3-venv \
-    xz-utils \
-    dos2unix \
-    vim \
-    nano \
-    mc \
-    openssh-server
+        dos2unix \
+        ca-certificates \
+        file \
+        locales \
+        git \
+        build-essential \
+        cmake \
+        ninja-build gperf \
+        device-tree-compiler \
+        wget \
+        curl \
+        python3 \
+        python3-pip \
+        python3-venv \
+        xz-utils \
+        dos2unix \
+        vim \
+        nano \
+        mc \
+        openssh-server
 
 # Set root password
 RUN echo "root:${PASSWORD}" | chpasswd
@@ -155,6 +155,51 @@ RUN cd /opt/toolchains/zephyr-sdk-${ZEPHYR_SDK_VERSION} && \
     tar xf hosttools_linux-${HOSTTYPE}.tar.xz && \
     rm hosttools_linux-${HOSTTYPE}.tar.xz && \
     bash zephyr-sdk-${HOSTTYPE}-hosttools-standalone-*.sh -y -d .
+
+#-------------------------------------------------------------------------------
+# VS Code Server
+
+# Set VS Code Server environment variables
+ENV VS_CODE_SERVER_VERSION=${VS_CODE_SERVER_VERSION}
+ENV VS_CODE_SERVER_PORT=${VS_CODE_SERVER_PORT}
+
+# Install VS Code Server
+RUN cd /tmp && \
+    wget ${WGET_ARGS} https://code-server.dev/install.sh && \
+    chmod +x install.sh && \
+    bash install.sh --version ${VS_CODE_SERVER_VERSION}
+
+# Download VS Code extensions (code-server extension manager does not work well)
+RUN cd /tmp && \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        wget ${WGET_ARGS} https://github.com/microsoft/vscode-cpptools/releases/download/v${VS_CODE_EXT_CPPTOOLS_VERSION}/cpptools-linux-x64.vsix -O cpptools.vsix; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        wget ${WGET_ARGS} https://github.com/microsoft/vscode-cpptools/releases/download/v${VS_CODE_EXT_CPPTOOLS_VERSION}/cpptools-linux-arm64.vsix -O cpptools.vsix; \
+    else \
+        echo "Unsupported architecture"; \
+        exit 1; \
+    fi && \
+    wget ${WGET_ARGS} https://github.com/microsoft/vscode-cmake-tools/releases/download/v${VS_CODE_EXT_CMAKETOOLS_VERSION}/cmake-tools.vsix -O cmake-tools.vsix && \
+    wget --compression=gzip ${WGET_ARGS} https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/hexeditor/${VS_CODE_EXT_HEX_EDITOR_VERSION}/vspackage -O hexeditor.vsix && \
+    wget --compression=gzip https://marketplace.visualstudio.com/_apis/public/gallery/publishers/nordic-semiconductor/vsextensions/nrf-devicetree/${VS_CODE_EXT_NRF_DEVICETREE_VERSION}/vspackage -O nordic-semiconductor.nrf-devicetree.vsix
+
+# Install extensions
+RUN cd /tmp && \
+    code-server --install-extension cpptools.vsix && \
+    code-server --install-extension cmake-tools.vsix && \
+    code-server --install-extension hexeditor.vsix && \
+    code-server --install-extension nordic-semiconductor.nrf-devicetree.vsix
+
+# Clean up
+RUN cd /tmp && \
+    rm install.sh && \
+    rm cpptools.vsix && \
+    rm cmake-tools.vsix && \
+    rm hexeditor.vsix && \
+    rm nordic-semiconductor.nrf-devicetree.vsix
+
+# Copy workspace configuration
+COPY scripts/zephyr.code-workspace /zephyr.code-workspace
 
 #-------------------------------------------------------------------------------
 # Optional Settings

--- a/Dockerfile.espressif
+++ b/Dockerfile.espressif
@@ -44,10 +44,10 @@ SHELL ["/bin/bash", "-c"]
 
 # Check if the target architecture is either x86_64 (amd64) or arm64 (aarch64)
 RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Architecture $TARGETARCH is supported."; \
+    echo "Architecture $TARGETARCH is supported."; \
     else \
-        echo "Unsupported architecture: $TARGETARCH"; \
-        exit 1; \
+    echo "Unsupported architecture: $TARGETARCH"; \
+    exit 1; \
     fi
 
 # Set non-interactive frontend for apt-get to skip any user confirmations
@@ -55,27 +55,27 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install base packages
 RUN apt-get -y update && \
-	apt-get install --no-install-recommends -y \
-        dos2unix \
-        ca-certificates \
-        file \
-        locales \
-        git \
-        build-essential \
-        cmake \
-        ninja-build gperf \
-        device-tree-compiler \
-        wget \
-        curl \
-        python3 \
-        python3-pip \
-        python3-venv \
-        xz-utils \
-        dos2unix \
-        vim \
-        nano \
-        mc \
-        openssh-server
+    apt-get install --no-install-recommends -y \
+    dos2unix \
+    ca-certificates \
+    file \
+    locales \
+    git \
+    build-essential \
+    cmake \
+    ninja-build gperf \
+    device-tree-compiler \
+    wget \
+    curl \
+    python3 \
+    python3-pip \
+    python3-venv \
+    xz-utils \
+    dos2unix \
+    vim \
+    nano \
+    mc \
+    openssh-server
 
 # Set root password
 RUN echo "root:${PASSWORD}" | chpasswd
@@ -90,8 +90,8 @@ RUN python3 -m pip install --no-cache-dir west
 
 # Clean up stale packages
 RUN apt-get clean -y && \
-	apt-get autoremove --purge -y && \
-	rm -rf /var/lib/apt/lists/*
+    apt-get autoremove --purge -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set up directories
 RUN mkdir -p /workspace/ && \
@@ -126,8 +126,8 @@ COPY scripts/espressif/west.yml /opt/toolchains/zephyr/west.yml
 
 # Instantiate west workspace and install tools
 RUN cd /opt/toolchains && \
-	west init -l zephyr && \
-	west update --narrow -o=--depth=1
+    west init -l zephyr && \
+    west update --narrow -o=--depth=1
 
 # Install module-specific blobs
 RUN cd /opt/toolchains && \
@@ -155,51 +155,6 @@ RUN cd /opt/toolchains/zephyr-sdk-${ZEPHYR_SDK_VERSION} && \
     tar xf hosttools_linux-${HOSTTYPE}.tar.xz && \
     rm hosttools_linux-${HOSTTYPE}.tar.xz && \
     bash zephyr-sdk-${HOSTTYPE}-hosttools-standalone-*.sh -y -d .
-
-#-------------------------------------------------------------------------------
-# VS Code Server
-
-# Set VS Code Server environment variables
-ENV VS_CODE_SERVER_VERSION=${VS_CODE_SERVER_VERSION}
-ENV VS_CODE_SERVER_PORT=${VS_CODE_SERVER_PORT}
-
-# Install VS Code Server
-RUN cd /tmp && \
-    wget ${WGET_ARGS} https://code-server.dev/install.sh && \
-    chmod +x install.sh && \
-    bash install.sh --version ${VS_CODE_SERVER_VERSION}
-
-# Download VS Code extensions (code-server extension manager does not work well)
-RUN cd /tmp && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        wget ${WGET_ARGS} https://github.com/microsoft/vscode-cpptools/releases/download/v${VS_CODE_EXT_CPPTOOLS_VERSION}/cpptools-linux-x64.vsix -O cpptools.vsix; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-        wget ${WGET_ARGS} https://github.com/microsoft/vscode-cpptools/releases/download/v${VS_CODE_EXT_CPPTOOLS_VERSION}/cpptools-linux-arm64.vsix -O cpptools.vsix; \
-    else \
-        echo "Unsupported architecture"; \
-        exit 1; \
-    fi && \
-    wget ${WGET_ARGS} https://github.com/microsoft/vscode-cmake-tools/releases/download/v${VS_CODE_EXT_CMAKETOOLS_VERSION}/cmake-tools.vsix -O cmake-tools.vsix && \
-    wget --compression=gzip ${WGET_ARGS} https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/hexeditor/${VS_CODE_EXT_HEX_EDITOR_VERSION}/vspackage -O hexeditor.vsix && \
-    wget --compression=gzip https://marketplace.visualstudio.com/_apis/public/gallery/publishers/nordic-semiconductor/vsextensions/nrf-devicetree/${VS_CODE_EXT_NRF_DEVICETREE_VERSION}/vspackage -O nordic-semiconductor.nrf-devicetree.vsix
-
-# Install extensions
-RUN cd /tmp && \
-    code-server --install-extension cpptools.vsix && \
-    code-server --install-extension cmake-tools.vsix && \
-    code-server --install-extension hexeditor.vsix && \
-    code-server --install-extension nordic-semiconductor.nrf-devicetree.vsix
-
-# Clean up
-RUN cd /tmp && \
-    rm install.sh && \
-    rm cpptools.vsix && \
-    rm cmake-tools.vsix && \
-    rm hexeditor.vsix && \
-    rm nordic-semiconductor.nrf-devicetree.vsix
-
-# Copy workspace configuration
-COPY scripts/zephyr.code-workspace /zephyr.code-workspace
 
 #-------------------------------------------------------------------------------
 # Optional Settings


### PR DESCRIPTION
Fixed devcontainer.json to use docker file instead of image

Tested on both macos and windows

![image](https://github.com/user-attachments/assets/d2323745-7e33-48c9-8e83-51dbad1dd248)


The devcontainer.json file sets specifc name for container for easy identification and management (in case we want to delete it using docker desktop)

<img width="1467" alt="image" src="https://github.com/user-attachments/assets/b6078b43-7a19-4fba-adda-5c3784f52150" />


Removes the installation of vscode extension in docker file

devcontainer.json handles it if properly loaded from vscode

User should use command pallet to open the folder in continer. 

1. open vscode insdie the project repo
2. cmd+shift+P / Ctrl+shift+P to open command pallet
3. Dev container: Open in container

This will allow vscode to create the image for first time 

In future, user can just open vscode and attach to running container or repeat above step

When folder is opened in vscode, it already asks to reopen in container


![image](https://github.com/user-attachments/assets/15672ec7-081e-414f-bc01-ce658e12d041)



Otherwise we can do it using command pallet 

